### PR TITLE
Introduce weakness support with CWE>OWASP compatibility

### DIFF
--- a/fixtures/vcr_cassettes/report.yml
+++ b/fixtures/vcr_cassettes/report.yml
@@ -207,6 +207,18 @@ http_interactions:
                 }
               ]
             },
+            "weakness": {
+              "data": {
+                "id": "1",
+                "type": "weakness",
+                "attributes": {
+                  "name": "Cleartext Storage of Sensitive Information",
+                  "description": "",
+                  "external_id": "CWE-312",
+                  "created_at": "2016-01-28T13:34:08.945Z"
+                }
+              }
+            },
             "activities": {
               "data": [
                 {

--- a/lib/hackerone/client/report.rb
+++ b/lib/hackerone/client/report.rb
@@ -1,23 +1,9 @@
+require_relative './weakness'
+
 module HackerOne
   module Client
     class Report
       PAYOUT_ACTIVITY_KEY = "activity-bounty-awarded"
-      CLASSIFICATION_MAPPING = {
-        "None Applicable" => "A0-Other",
-        "Denial of Service" => "A0-Other",
-        "Memory Corruption" => "A0-Other",
-        "Cryptographic Issue" => "A0-Other",
-        "Privilege Escalation" => "A0-Other",
-        "UI Redressing (Clickjacking)" => "A0-Other",
-        "Command Injection" => "A1-Injection",
-        "Remote Code Execution" => "A1-Injection",
-        "SQL Injection" => "A1-Injection",
-        "Authentication" => "A2-AuthSession",
-        "Cross-Site Scripting (XSS)" => "A3-XSS",
-        "Information Disclosure" => "A6-DataExposure",
-        "Cross-Site Request Forgery (CSRF)" => "A8-CSRF",
-        "Unvalidated / Open Redirect" => "A10-Redirects"
-      }
 
       def initialize(report)
         @report = report
@@ -69,15 +55,12 @@ module HackerOne
         attributes[:vulnerability_information]
       end
 
-      # Do our best to map the value that hackerone provides and the reporter sets
-      # to the OWASP Top 10. Take the first match since multiple values can be set.
-      # This is used for the issue label.
-      def classification_label
-        owasp_mapping = vulnerability_types.map do |vuln_type|
-          CLASSIFICATION_MAPPING[vuln_type[:attributes][:name]]
-        end.flatten.first
+      def weakness
+        @weakness ||= Weakness.new relationships[:weakness][:data][:attributes]
+      end
 
-        owasp_mapping || CLASSIFICATION_MAPPING["None Applicable"]
+      def classification_label
+        weakness.to_owasp
       end
 
       # Bounty writeups just use the key, and not the label value.

--- a/lib/hackerone/client/version.rb
+++ b/lib/hackerone/client/version.rb
@@ -1,5 +1,5 @@
 module Hackerone
   module Client
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/hackerone/client/weakness.rb
+++ b/lib/hackerone/client/weakness.rb
@@ -1,0 +1,43 @@
+module HackerOne
+  module Client
+    class Weakness
+      class << self
+        def extract_cwe_number(cwe)
+          fail StandardError::ArgumentError unless cwe.upcase.start_with?('CWE-')
+
+          cwe[4..-1].to_i
+        end
+      end
+
+      OWASP_TOP_10_2013_TO_CWE = {
+        'A1-Injection' => [77, 78, 88, 89, 90, 91, 564],
+        'A2-AuthSession' =>
+          [287, 613, 522, 256, 384, 472, 346, 441, 523, 620, 640, 319, 311],
+        'A3-XSS' => [79],
+        'A4-IDOR' => [639, 99, 22],
+        'A5-SecurityMisconfiguration' => [16, 2, 215, 548, 209],
+        'A6-DataExposure' => [312, 319, 310, 326, 320, 311, 325, 328, 327],
+        'A7-MissingAccessControl' => [285, 287],
+        'A8-CSRF' => [352, 642, 613, 346, 441],
+        'A9-ComponentsWithKnownVulnerabilities' => [],
+        'A10-Redirects' => [601],
+      }.freeze
+
+      OWASP_DEFAULT = 'A0-Other'.freeze
+
+      def initialize(weakness)
+        @attributes = weakness
+      end
+
+      def to_owasp
+        OWASP_TOP_10_2013_TO_CWE.map do |owasp, cwes|
+          owasp if cwes.include?(self.class.extract_cwe_number(to_cwe))
+        end.compact.first || OWASP_DEFAULT
+      end
+
+      def to_cwe
+        @attributes[:external_id]
+      end
+    end
+  end
+end

--- a/lib/hackerone/client/weakness.rb
+++ b/lib/hackerone/client/weakness.rb
@@ -5,7 +5,7 @@ module HackerOne
         def extract_cwe_number(cwe)
           fail StandardError::ArgumentError unless cwe.upcase.start_with?('CWE-')
 
-          cwe[4..-1].to_i
+          cwe.split('CWE-').last.to_i
         end
       end
 

--- a/lib/hackerone/client/weakness.rb
+++ b/lib/hackerone/client/weakness.rb
@@ -14,12 +14,12 @@ module HackerOne
         'A2-AuthSession' =>
           [287, 613, 522, 256, 384, 472, 346, 441, 523, 620, 640, 319, 311],
         'A3-XSS' => [79],
-        'A4-IDOR' => [639, 99, 22],
-        'A5-SecurityMisconfiguration' => [16, 2, 215, 548, 209],
+        'A4-DirectObjRef' => [639, 99, 22],
+        'A5-Misconfig' => [16, 2, 215, 548, 209],
         'A6-DataExposure' => [312, 319, 310, 326, 320, 311, 325, 328, 327],
-        'A7-MissingAccessControl' => [285, 287],
+        'A7-MissingACL' => [285, 287],
         'A8-CSRF' => [352, 642, 613, 346, 441],
-        'A9-ComponentsWithKnownVulnerabilities' => [],
+        'A9-KnownVuln' => [],
         'A10-Redirects' => [601],
       }.freeze
 

--- a/spec/hackerone/client/report_spec.rb
+++ b/spec/hackerone/client/report_spec.rb
@@ -37,4 +37,10 @@ RSpec.describe HackerOne::Client::Report do
   it "maps results to the owasp top 10" do
     expect(report.classification_label).to eq("A6-DataExposure")
   end
+
+  describe "#weakness" do
+    it 'returns a weakness instance' do
+      expect(report.weakness).to be_a(HackerOne::Client::Weakness)
+    end
+  end
 end

--- a/spec/hackerone/client/weakness_spec.rb
+++ b/spec/hackerone/client/weakness_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+RSpec.describe HackerOne::Client::Weakness do
+  describe ".extract_cwe_number" do
+    context "with invalid input" do
+      it do
+        expect { described_class.extract_cwe_number("1337")
+          .to raise_error StandardError::ArgumentError }
+      end
+    end
+
+    context "with valid input" do
+      it { expect(described_class.extract_cwe_number("CWE-134")).to eq(134) }
+    end
+  end
+
+  describe "#to_cwe" do
+    it "returns the external_id" do
+      expect(described_class.new(:external_id => "CWE-134").to_cwe)
+        .to eq("CWE-134")
+    end
+  end
+
+  describe "#to_owasp" do
+    subject { described_class.new(:external_id => cwe).to_owasp }
+
+    context "unmappable CWE" do
+      let(:cwe) { "CWE-33" }
+
+      it { is_expected.to eq("A0-Other") }
+    end
+
+    context "mappable CWE" do
+      let(:cwe) { "CWE-77" }
+
+      it { is_expected.to eq("A1-Injection") }
+    end
+  end
+end


### PR DESCRIPTION
With the introduction of the new CWEs, HackerOne is phasing out the old, legacy vulnerability types. This PR will introduce a new weakness object that contains additional logic to infer the CWE to the OWASP Top 10 (2013). The `classification_label` in the `Report` class has been left in the class for an easy upgrade. In future versions of the gem, this method could be removed. When it is removed, the weakness information itself should be used, or `<report instance>.weakness.to_owasp` can be called.