### PR TITLE
Adds activities to reports

### DIFF
--- a/lib/hackerone/client.rb
+++ b/lib/hackerone/client.rb
@@ -2,6 +2,7 @@ require "faraday"
 require 'active_support/time'
 require_relative "client/version"
 require_relative "client/report"
+require_relative "client/activity"
 
 module HackerOne
   module Client

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -28,6 +28,7 @@ module HackerOne
 
       class BountyAwarded < Activity
         delegate :bounty_amount, to: :attributes
+        delegate :bonus_amount, to: :attributes
       end
 
       class SwagAwarded < Activity
@@ -57,6 +58,7 @@ module HackerOne
         activity_type_class = ACTIVITY_TYPE_CLASS_MAPPING.fetch \
           activity_data[:type], Activity
 
+        # puts activity_data
         activity_type_class.new activity_data
       end
     end

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -1,25 +1,47 @@
 module HackerOne
   module Client
-    class Activity
-      PAYOUT_ACTIVITY_KEY = "activity-bounty-awarded"
+    module Activities
+      BOUNTY_AWARDED_ACTIVITY_KEY = "activity-bounty-awarded"
+      SWAG_AWARDED_ACTIVITY_KEY = "activity-swag-awarded"
 
-      delegate :bounty_amount, to: :attributes
+      class Activity
+        delegate :message, :created_at, :updated_at, to: :attributes
 
-      def initialize(activity)
-        @activity = OpenStruct.new(activity)
+        def initialize(activity)
+          @activity = OpenStruct.new activity
+        end
+
+        def internal?
+          attributes.internal
+        end
+
+        private
+
+        def attributes
+          OpenStruct.new(activity.attributes)
+        end
+
+        attr_reader :activity
       end
 
-      def payout?
-        activity.type == PAYOUT_ACTIVITY_KEY
+      class BountyAwarded < Activity
+        delegate :bounty_amount, to: :attributes
       end
 
-      private
-
-      def attributes
-        OpenStruct.new(activity.attributes)
+      class SwagAwarded < Activity
       end
 
-      attr_reader :activity
+      def self.build(activity_data)
+        activity_type_class_mapping = {
+          BOUNTY_AWARDED_ACTIVITY_KEY => BountyAwarded,
+          SWAG_AWARDED_ACTIVITY_KEY => SwagAwarded
+        }
+
+        activity_type_class = \
+          activity_type_class_mapping.fetch(activity_data[:type], Activity)
+
+        activity_type_class.new activity_data
+      end
     end
   end
 end

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -27,8 +27,15 @@ module HackerOne
       end
 
       class BountyAwarded < Activity
-        delegate :bounty_amount, to: :attributes
-        delegate :bonus_amount, to: :attributes
+        def bounty_amount
+          formatted_bounty_amount = attributes.bounty_amount || "0"
+          formatted_bounty_amount.gsub(/[^\d]/, "").to_i
+        end
+
+        def bonus_amount
+          formatted_bonus_amount = attributes.bonus_amount || "0"
+          formatted_bonus_amount.gsub(/[^\d]/, "").to_i
+        end
       end
 
       class SwagAwarded < Activity

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -58,7 +58,6 @@ module HackerOne
         activity_type_class = ACTIVITY_TYPE_CLASS_MAPPING.fetch \
           activity_data[:type], Activity
 
-        # puts activity_data
         activity_type_class.new activity_data
       end
     end

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -1,0 +1,25 @@
+module HackerOne
+  module Client
+    class Activity
+      PAYOUT_ACTIVITY_KEY = "activity-bounty-awarded"
+
+      delegate :bounty_amount, to: :attributes
+
+      def initialize(activity)
+        @activity = OpenStruct.new(activity)
+      end
+
+      def payout?
+        activity.type == PAYOUT_ACTIVITY_KEY
+      end
+
+      private
+
+      def attributes
+        OpenStruct.new(activity.attributes)
+      end
+
+      attr_reader :activity
+    end
+  end
+end

--- a/lib/hackerone/client/report.rb
+++ b/lib/hackerone/client/report.rb
@@ -1,10 +1,9 @@
 require_relative './weakness'
+require_relative './activity'
 
 module HackerOne
   module Client
     class Report
-      PAYOUT_ACTIVITY_KEY = "activity-bounty-awarded"
-
       def initialize(report)
         @report = report
       end
@@ -68,17 +67,20 @@ module HackerOne
         classification_label().split("-").first
       end
 
+      def activities
+        relationships.dig(:activities, :data)&.map do |activity_data|
+          Activity.new(activity_data)
+        end
+      end
+
       private
+
       def payments
-        activities.select { |activity| activity[:type] == PAYOUT_ACTIVITY_KEY }
+        activities.select(&:payout?)
       end
 
       def payment_amount(payment)
-        payment.fetch(:attributes, {}).fetch(:bounty_amount, "0").gsub(/[^\d]/, "").to_i
-      end
-
-      def activities
-        relationships.fetch(:activities, {}).fetch(:data, [])
+        payment.bounty_amount.gsub(/[^\d]/, "").to_i
       end
 
       def attributes

--- a/lib/hackerone/client/report.rb
+++ b/lib/hackerone/client/report.rb
@@ -69,14 +69,14 @@ module HackerOne
 
       def activities
         relationships.dig(:activities, :data)&.map do |activity_data|
-          Activity.new(activity_data)
+          Activities.build(activity_data)
         end
       end
 
       private
 
       def payments
-        activities.select(&:payout?)
+        activities.select { |activity| activity.is_a? Activities::BountyAwarded }
       end
 
       def payment_amount(payment)

--- a/lib/hackerone/client/report.rb
+++ b/lib/hackerone/client/report.rb
@@ -80,7 +80,7 @@ module HackerOne
       end
 
       def payment_amount(payment)
-        payment.bounty_amount.gsub(/[^\d]/, "").to_i
+        payment.bounty_amount
       end
 
       def attributes

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -3,7 +3,6 @@ require 'active_support/core_ext/hash'
 
 RSpec.describe HackerOne::Client::Activities do
   describe HackerOne::Client::Activities::BountyAwarded do
-    # delegate :bounty_amount, to: :attributes
     let(:example) do
       {
         'id' => '1337',

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -1,0 +1,260 @@
+require 'spec_helper'
+require 'active_support/core_ext/hash'
+
+RSpec.describe HackerOne::Client::Activities do
+  describe HackerOne::Client::Activities::BountyAwarded do
+    # delegate :bounty_amount, to: :attributes
+    let(:example) do
+      {
+        'id' => '1337',
+        'type' => 'activity-bounty-awarded',
+        'attributes' => {
+          'message' => 'Bounty Awarded!',
+          'created_at' => '2016-02-02T04:05:06.000Z',
+          'updated_at' => '2016-02-02T04:05:06.000Z',
+          'internal' => false,
+          'bounty_amount' => '500',
+          'bonus_amount' => '50'
+        },
+        'relationships' => {
+          'actor' => {
+            'data' => {
+              'id' => '1337',
+              'type' => 'program',
+              'attributes' => {
+                'handle' => 'security',
+                'created_at' => '2016-02-02T04:05:06.000Z',
+                'updated_at' => '2016-02-02T04:05:06.000Z'
+              }
+            }
+          }
+        }
+      }.with_indifferent_access
+    end
+
+    it 'creates the activity type with attributes' do
+      activity = HackerOne::Client::Activities.build example
+
+      expect(activity.class).to eq described_class
+      expect(activity.bounty_amount).to eq '500'
+      expect(activity.bonus_amount).to eq '50'
+    end
+  end
+
+  describe HackerOne::Client::Activities::SwagAwarded do
+    let(:example) do
+      {
+        'id': '1337',
+        'type': 'activity-swag-awarded',
+        'attributes': {
+          'message': 'Swag Awarded!',
+          'created_at': '2016-02-02T04:05:06.000Z',
+          'updated_at': '2016-02-02T04:05:06.000Z',
+          'internal': false
+        },
+        'relationships': {
+          'actor': {
+            'data': {
+              'id': '1337',
+              'type': 'user',
+              'attributes': {
+                'username': 'api-example',
+                'name': 'API Example',
+                'disabled': false,
+                'created_at': '2016-02-02T04:05:06.000Z',
+                'profile_picture': {
+                  '62x62': '/assets/avatars/default.png',
+                  '82x82': '/assets/avatars/default.png',
+                  '110x110': '/assets/avatars/default.png',
+                  '260x260': '/assets/avatars/default.png'
+                }
+              }
+            }
+          },
+          'swag': {
+            'data': {
+              'id': '1337',
+              'type': 'swag',
+              'attributes': {
+                'sent': false,
+                'created_at': '2016-02-02T04:05:06.000Z'
+              },
+              'relationships': {
+                'address': {
+                  'data': {
+                    'id': '1337',
+                    'type': 'address',
+                    'attributes': {
+                      'name': 'Jane Doe',
+                      'street': '535 Mission Street',
+                      'city': 'San Francisco',
+                      'postal_code': '94105',
+                      'state': 'CA',
+                      'country': 'United States of America',
+                      'created_at': '2016-02-02T04:05:06.000Z',
+                      'tshirt_size': 'Large',
+                      'phone_number': '+1-510-000-0000'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }.with_indifferent_access
+    end
+
+    it 'creates the activity type with attributes' do
+      activity = HackerOne::Client::Activities.build example
+
+      expect(activity.class).to eq described_class
+      expect(activity.swag).to_not be_nil
+    end
+  end
+
+  describe HackerOne::Client::Activities::UserAssignedToBug do
+    let(:example) do
+      {
+        "id": "1337",
+        "type": "activity-user-assigned-to-bug",
+        "attributes": {
+          "message": "User Assigned To Bug!",
+          "created_at": "2016-02-02T04:05:06.000Z",
+          "updated_at": "2016-02-02T04:05:06.000Z",
+          "internal": true
+        },
+        "relationships": {
+          "actor": {
+            "data": {
+              "id": "1337",
+              "type": "user",
+              "attributes": {
+                "username": "api-example",
+                "name": "API Example",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          },
+          "assigned_user": {
+            "data": {
+              "id": "1336",
+              "type": "user",
+              "attributes": {
+                "username": "other_user",
+                "name": "Other User",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          }
+        }
+      }.with_indifferent_access
+    end
+
+    it 'creates the activity type with attributes' do
+      activity = HackerOne::Client::Activities.build example
+
+      expect(activity.class).to eq described_class
+      expect(activity.assigned_user).to_not be_nil
+    end
+  end
+
+  describe HackerOne::Client::Activities::BugTriaged do
+    let(:example) do
+      {
+        "id": "1337",
+        "type": "activity-bug-triaged",
+        "attributes": {
+          "message": "Bug Triaged!",
+          "created_at": "2016-02-02T04:05:06.000Z",
+          "updated_at": "2016-02-02T04:05:06.000Z",
+          "internal": false
+        },
+        "relationships": {
+          "actor": {
+            "data": {
+              "id": "1337",
+              "type": "user",
+              "attributes": {
+                "username": "api-example",
+                "name": "API Example",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it 'creates the activity type with attributes' do
+      activity = HackerOne::Client::Activities.build example
+
+      expect(activity.class).to eq described_class
+    end
+  end
+
+  describe HackerOne::Client::Activities::ReferenceIdAdded do
+    let(:example) do
+      {
+        "id": "1337",
+        "type": "activity-reference-id-added",
+        "attributes": {
+          "message": "Reference Id Added!",
+          "created_at": "2016-02-02T04:05:06.000Z",
+          "updated_at": "2016-02-02T04:05:06.000Z",
+          "internal": true,
+          "reference": "reference",
+          "reference_url": "https://example.com/reference"
+        },
+        "relationships": {
+          "actor": {
+            "data": {
+              "id": "1337",
+              "type": "user",
+              "attributes": {
+                "username": "api-example",
+                "name": "API Example",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          }
+        }
+      }.with_indifferent_access
+    end
+
+    it 'creates the activity type with attributes' do
+      activity = HackerOne::Client::Activities.build example
+
+      expect(activity.class).to eq described_class
+      expect(activity.reference).to eq "reference"
+      expect(activity.reference_url).to eq "https://example.com/reference"
+    end
+  end
+end

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -35,8 +35,20 @@ RSpec.describe HackerOne::Client::Activities do
       activity = HackerOne::Client::Activities.build example
 
       expect(activity.class).to eq described_class
-      expect(activity.bounty_amount).to eq '500'
-      expect(activity.bonus_amount).to eq '50'
+      expect(activity.bounty_amount).to eq 500
+      expect(activity.bonus_amount).to eq 50
+    end
+
+    it 'does not fail when bounty or bonus amount is not given' do
+      example = {
+        'type' => 'activity-bounty-awarded',
+        'attributes' => {}
+      }.with_indifferent_access
+
+      activity = HackerOne::Client::Activities.build example
+
+      expect(activity.bounty_amount).to eq 0
+      expect(activity.bonus_amount).to eq 0
     end
   end
 

--- a/spec/hackerone/client/report_spec.rb
+++ b/spec/hackerone/client/report_spec.rb
@@ -43,4 +43,10 @@ RSpec.describe HackerOne::Client::Report do
       expect(report.weakness).to be_a(HackerOne::Client::Weakness)
     end
   end
+
+  describe "#activities" do
+    it "returns a list of activities" do
+      expect(report.activities).to all(be_an(HackerOne::Client::Activity))
+    end
+  end
 end

--- a/spec/hackerone/client/report_spec.rb
+++ b/spec/hackerone/client/report_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe HackerOne::Client::Report do
 
   describe "#activities" do
     it "returns a list of activities" do
-      expect(report.activities).to all(be_an(HackerOne::Client::Activity))
+      expect(report.activities).to all(be_an(HackerOne::Client::Activities::Activity))
     end
   end
 end


### PR DESCRIPTION
Hello Oreoshake, 

I'm working on implementing #4. I've added an activity class to support comments and other activity types. With this new activity type, implementing `comment?` to figure out if the activity is a comment is pretty straight forward. Same goes for `internal?`. 

I still have to do some cleaning to complete this PR. There are a couple of things I do a bit differently in this PR, mostly syntax. Plus, I'd like to add some more delegators as well; all activities have an actor, message, and some other fields.

Thanks,

Willian




