### PR TITLE
Add ability to comment on issues

### DIFF
--- a/fixtures/vcr_cassettes/add_comment.yml
+++ b/fixtures/vcr_cassettes/add_comment.yml
@@ -1,0 +1,157 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hackerone.com/v1/reports/215230/activities
+    body:
+      encoding: UTF-8
+      string: "{\"data\":{\"type\":\"activity-comment\",\"attributes\":{\"message\":\"I
+        am an internal comment\",\"internal\":true}}}"
+    headers:
+      Authorization:
+      - Basic ==
+      User-Agent:
+      - Faraday v0.11.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 20 Jul 2017 19:31:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dc6e0045651a0dfb269f81402a0ee74051500579079; expires=Fri, 20-Jul-18
+        19:31:19 GMT; path=/; Domain=api.hackerone.com; HttpOnly
+      X-Request-Id:
+      - 552f630f-8f34-4e39-b49f-f4cf6046dd1b
+      Etag:
+      - W/"213a426a179715f6d44f095780be6b17"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        www.youtube-nocookie.com; connect-src ''self'' www.google-analytics.com errors.hackerone.net;
+        font-src ''self''; form-action ''self''; frame-ancestors ''none''; img-src
+        ''self'' data: cover-photos.hackerone-user-content.com hackathon-photos.hackerone-user-content.com
+        profile-photos.hackerone-user-content.com hackerone-attachments.s3.amazonaws.com;
+        media-src ''self'' hackerone-attachments.s3.amazonaws.com; script-src ''self''
+        www.google-analytics.com; style-src ''self'' ''unsafe-inline''; report-uri
+        https://errors.hackerone.net/api/30/csp-report/?sentry_key=61c1e2f50d21487c97a071737701f598'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=";
+        pin-sha256="K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q="; pin-sha256="iie1VXtL7HzAMF+/PVPR9xzT80kQxdZeJ+zduCB3uj0=";
+        pin-sha256="cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A="; pin-sha256="bIlWcjiKq1mftH/xd7Hw1JO77Cr+Gv+XYcGUQWwO+A4=";
+        pin-sha256="tXD+dGAP8rGY4PW1be90cOYEwg7pZ4G+yPZmIZWPTSg="; max-age=600; includeSubDomains;
+        report-uri="https://hackerone.report-uri.io/r/default/hpkp/reportOnly"
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 3818570f7dce53a2-LAX
+    body:
+      encoding: UTF-8
+      string: "{\"data\":{\"type\":\"activity-comment\",\"id\":\"1854710\",\"attributes\":{\"message\":\"I
+        am an internal comment\",\"created_at\":\"2017-07-20T19:31:19.733Z\",\"updated_at\":\"2017-07-20T19:31:19.733Z\",\"internal\":true},\"relationships\":{\"actor\":{\"data\":{\"type\":\"user\",\"id\":\"185283\",\"attributes\":{\"username\":\"oreoshake-test-token-4\",\"name\":null,\"disabled\":false,\"created_at\":\"2017-07-20T19:22:56.881Z\",\"profile_picture\":{\"62x62\":\"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png\",\"82x82\":\"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png\",\"110x110\":\"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png\",\"260x260\":\"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png\"}}}}}}}"
+    http_version:
+  recorded_at: Thu, 20 Jul 2017 19:31:19 GMT
+- request:
+    method: post
+    uri: https://api.hackerone.com/v1/reports/132170/activities
+    body:
+      encoding: UTF-8
+      string: "{\"data\":{\"type\":\"activity-comment\",\"attributes\":{\"message\":\"I
+        am not an internal comment\",\"internal\":false}}}"
+    headers:
+      Authorization:
+      - Basic ==
+      User-Agent:
+      - Faraday v0.11.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 20 Jul 2017 19:31:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d104d11a7dd0d4d546ad5de4a34ae70091500579080; expires=Fri, 20-Jul-18
+        19:31:20 GMT; path=/; Domain=api.hackerone.com; HttpOnly
+      X-Request-Id:
+      - d3253b5d-6f40-4070-8a49-2c9fddc85b6f
+      Etag:
+      - W/"5409aa55cb4b50a7801681b8f529bcfd"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        www.youtube-nocookie.com; connect-src ''self'' www.google-analytics.com errors.hackerone.net;
+        font-src ''self''; form-action ''self''; frame-ancestors ''none''; img-src
+        ''self'' data: cover-photos.hackerone-user-content.com hackathon-photos.hackerone-user-content.com
+        profile-photos.hackerone-user-content.com hackerone-attachments.s3.amazonaws.com;
+        media-src ''self'' hackerone-attachments.s3.amazonaws.com; script-src ''self''
+        www.google-analytics.com; style-src ''self'' ''unsafe-inline''; report-uri
+        https://errors.hackerone.net/api/30/csp-report/?sentry_key=61c1e2f50d21487c97a071737701f598'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=";
+        pin-sha256="K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q="; pin-sha256="iie1VXtL7HzAMF+/PVPR9xzT80kQxdZeJ+zduCB3uj0=";
+        pin-sha256="cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A="; pin-sha256="bIlWcjiKq1mftH/xd7Hw1JO77Cr+Gv+XYcGUQWwO+A4=";
+        pin-sha256="tXD+dGAP8rGY4PW1be90cOYEwg7pZ4G+yPZmIZWPTSg="; max-age=600; includeSubDomains;
+        report-uri="https://hackerone.report-uri.io/r/default/hpkp/reportOnly"
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 381857128fff7820-LAX
+    body:
+      encoding: UTF-8
+      string: "{\"data\":{\"type\":\"activity-comment\",\"id\":\"1854711\",\"attributes\":{\"message\":\"I
+        am not an internal comment\",\"created_at\":\"2017-07-20T19:31:20.181Z\",\"updated_at\":\"2017-07-20T19:31:20.181Z\",\"internal\":false},\"relationships\":{\"actor\":{\"data\":{\"type\":\"user\",\"id\":\"185283\",\"attributes\":{\"username\":\"oreoshake-test-token-4\",\"name\":null,\"disabled\":false,\"created_at\":\"2017-07-20T19:22:56.881Z\",\"profile_picture\":{\"62x62\":\"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png\",\"82x82\":\"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png\",\"110x110\":\"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png\",\"260x260\":\"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png\"}}}}}}}"
+    http_version:
+  recorded_at: Thu, 20 Jul 2017 19:31:20 GMT
+recorded_with: VCR 3.0.3

--- a/lib/hackerone/client.rb
+++ b/lib/hackerone/client.rb
@@ -161,6 +161,27 @@ module HackerOne
         post("reports/#{id}/state_changes", body)
       end
 
+      # Add a comment to a report. By default, internal comments will be added.
+      #
+      # id: the ID of the report
+      # message: the content of the comment that will be created
+      # internal: "team only" comment (true, default) or "all participants"
+      def add_comment(id, message, internal: true)
+        fail ArgumentError, "message is required" if message.blank?
+
+        body = {
+          data: {
+            type: "activity-comment",
+            attributes: {
+              message: message,
+              internal: internal
+            }
+          }
+        }
+
+        post("reports/#{id}/activities", body)
+      end
+
       ## Public: retrieve a report
       #
       # id: the ID of a specific report

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -53,12 +53,17 @@ module HackerOne
         delegate :reference, :reference_url, to: :attributes
       end
 
+      class CommentAdded < Activity
+        delegate :message, :internal, to: :attributes
+      end
+
       ACTIVITY_TYPE_CLASS_MAPPING = {
         'activity-bounty-awarded' => BountyAwarded,
         'activity-swag-awarded' => SwagAwarded,
         'activity-user-assigned-to-bug' => UserAssignedToBug,
         'activity-bug-triaged' => BugTriaged,
-        'activity-reference-id-added' => ReferenceIdAdded
+        'activity-reference-id-added' => ReferenceIdAdded,
+        'activity-comment' => CommentAdded
       }.freeze
 
       def self.build(activity_data)

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -123,6 +123,49 @@ RSpec.describe HackerOne::Client::Activities do
     end
   end
 
+  describe HackerOne::Client::Activities::CommentAdded do
+    let(:example) do
+      {
+        "id" => "1337",
+        "type" => "activity-comment",
+        "attributes" => {
+          "message" => "A fix has been deployed. Can you retest, please?",
+          "created_at" => "2016-02-02T04:05:06.000Z",
+          "updated_at" => "2016-02-02T04:05:06.000Z",
+          "internal" => false
+        },
+        "relationships" => {
+          "actor" => {
+            "data" => {
+              "id" => "1337",
+              "type" => "user",
+              "attributes" => {
+                "username" => "api-example",
+                "name" => "API Example",
+                "disabled" => false,
+                "created_at" => "2016-02-02T04:05:06.000Z",
+                "profile_picture" => {
+                  "62x62" => "/assets/avatars/default.png",
+                  "82x82" => "/assets/avatars/default.png",
+                  "110x110" => "/assets/avatars/default.png",
+                  "260x260" => "/assets/avatars/default.png"
+                }
+              }
+            }
+          }
+        }
+      }.with_indifferent_access
+    end
+
+    it 'creates the activity type with attributes' do
+      activity = HackerOne::Client::Activities.build example
+
+      expect(activity.class).to eq described_class
+      expect(activity.message).to_not be_nil
+      expect(activity.internal).to_not be_nil
+    end
+  end
+
   describe HackerOne::Client::Activities::UserAssignedToBug do
     let(:example) do
       {

--- a/spec/hackerone/client_spec.rb
+++ b/spec/hackerone/client_spec.rb
@@ -96,6 +96,26 @@ RSpec.describe HackerOne::Client do
     end
   end
 
+  context "#add_comment" do
+    it "adds an internal comment by default" do
+      VCR.use_cassette(:add_comment) do
+        response = api.add_comment(215230, "I am an internal comment")
+        comment = HackerOne::Client::Activities.build(response)
+        expect(comment).to be_a(HackerOne::Client::Activities::CommentAdded)
+        expect(comment.internal).to be true
+      end
+    end
+
+    it "allows comments for all participants" do
+      VCR.use_cassette(:add_comment) do
+        response = api.add_comment(132170, "I am not an internal comment", internal: false)
+        comment = HackerOne::Client::Activities.build(response)
+        expect(comment).to be_a(HackerOne::Client::Activities::CommentAdded)
+        expect(comment.internal).to be false
+      end
+    end
+  end
+
   context "#reports" do
     it "raises an error if no program is supplied" do
       expect { HackerOne::Client::Api.new.reports }.to raise_error(ArgumentError)


### PR DESCRIPTION
Closes #4

See https://api.hackerone.com/docs/v1#/reports/comments/create

Post a comment (defaulting to "internal" comments) and ensure the result can be parsed as a `CommentAdded` activity.