### PR TITLE
Implements award_bounty, award_swag, and suggest_award

### DIFF
--- a/fixtures/vcr_cassettes/award_a_bounty.yml
+++ b/fixtures/vcr_cassettes/award_a_bounty.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hackerone.com/v1/reports/200/bounties
+    body:
+      encoding: UTF-8
+      string: '{"data":{"message":"Thanks for the great report!","amount":1330,"bonus_amount":7}}'
+    headers:
+      Authorization:
+      - Basic NOPE
+      User-Agent:
+      - Faraday v0.13.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 22 Aug 2017 15:03:46 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d068dbf4c0fe50bf2d44f3cb68388bbd11503414225; expires=Wed, 22-Aug-18
+        15:03:45 GMT; path=/; Domain=api.hackerone.com; HttpOnly
+      X-Request-Id:
+      - 723974f5-3988-4f59-ae9e-70198ab702d9
+      Etag:
+      - W/"f8d7a0dd4f35f9a89533b12bc651ccca"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        www.youtube-nocookie.com; connect-src ''self'' www.google-analytics.com errors.hackerone.net;
+        font-src ''self''; form-action ''self''; frame-ancestors ''none''; img-src
+        ''self'' data: cover-photos.hackerone-user-content.com hackathon-photos.hackerone-user-content.com
+        profile-photos.hackerone-user-content.com hackerone-attachments.s3.amazonaws.com;
+        media-src ''self'' hackerone-attachments.s3.amazonaws.com; script-src ''self''
+        www.google-analytics.com; style-src ''self'' ''unsafe-inline''; report-uri
+        https://errors.hackerone.net/api/30/csp-report/?sentry_key=61c1e2f50d21487c97a071737701f598'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=";
+        pin-sha256="K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q="; pin-sha256="iie1VXtL7HzAMF+/PVPR9xzT80kQxdZeJ+zduCB3uj0=";
+        pin-sha256="cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A="; pin-sha256="bIlWcjiKq1mftH/xd7Hw1JO77Cr+Gv+XYcGUQWwO+A4=";
+        pin-sha256="tXD+dGAP8rGY4PW1be90cOYEwg7pZ4G+yPZmIZWPTSg="; max-age=600; includeSubDomains;
+        report-uri="https://hackerone.report-uri.io/r/default/hpkp/reportOnly"
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 3926b87dce5c0761-AMS
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"58549","type":"bounty","attributes":{"amount":"1330.00","bonus_amount":"7.00","awarded_amount":"1330.00","awarded_bonus_amount":"7.00","awarded_currency":"USD","created_at":"2017-08-22T15:03:46.183Z"}}}'
+    http_version: 
+  recorded_at: Tue, 22 Aug 2017 15:03:45 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/award_swag.yml
+++ b/fixtures/vcr_cassettes/award_swag.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hackerone.com/v1/reports/200/swags
+    body:
+      encoding: UTF-8
+      string: '{"data":{"message":"Enjoy this cool swag!"}}'
+    headers:
+      Authorization:
+      - Basic NOPE
+      User-Agent:
+      - Faraday v0.13.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 22 Aug 2017 15:09:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d09e856041f6ae0c3a2a91e50ba326b211503414583; expires=Wed, 22-Aug-18
+        15:09:43 GMT; path=/; Domain=api.hackerone.com; HttpOnly
+      X-Request-Id:
+      - 8d9d9f70-ee1e-49a8-b396-0d763383d9e2
+      Etag:
+      - W/"31f75873e2b18f42b69b8d094d270f58"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        www.youtube-nocookie.com; connect-src ''self'' www.google-analytics.com errors.hackerone.net;
+        font-src ''self''; form-action ''self''; frame-ancestors ''none''; img-src
+        ''self'' data: cover-photos.hackerone-user-content.com hackathon-photos.hackerone-user-content.com
+        profile-photos.hackerone-user-content.com hackerone-attachments.s3.amazonaws.com;
+        media-src ''self'' hackerone-attachments.s3.amazonaws.com; script-src ''self''
+        www.google-analytics.com; style-src ''self'' ''unsafe-inline''; report-uri
+        https://errors.hackerone.net/api/30/csp-report/?sentry_key=61c1e2f50d21487c97a071737701f598'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=";
+        pin-sha256="K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q="; pin-sha256="iie1VXtL7HzAMF+/PVPR9xzT80kQxdZeJ+zduCB3uj0=";
+        pin-sha256="cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A="; pin-sha256="bIlWcjiKq1mftH/xd7Hw1JO77Cr+Gv+XYcGUQWwO+A4=";
+        pin-sha256="tXD+dGAP8rGY4PW1be90cOYEwg7pZ4G+yPZmIZWPTSg="; max-age=600; includeSubDomains;
+        report-uri="https://hackerone.report-uri.io/r/default/hpkp/reportOnly"
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 3926c13b49050761-AMS
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"2057","type":"swag","attributes":{"sent":false,"created_at":"2017-08-22T15:09:44.176Z"}}}'
+    http_version: 
+  recorded_at: Tue, 22 Aug 2017 15:09:43 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/suggest_a_bounty.yml
+++ b/fixtures/vcr_cassettes/suggest_a_bounty.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hackerone.com/v1/reports/200/bounty_suggestions
+    body:
+      encoding: UTF-8
+      string: '{"data":{"message":"This report is great, I think we should award a
+        high bounty.","amount":5000,"bonus_amount":2500}}'
+    headers:
+      Authorization:
+      - Basic NOPE
+      User-Agent:
+      - Faraday v0.13.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 22 Aug 2017 15:10:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d024b34c2f975a4ee9ede2a5bc288fdc11503414602; expires=Wed, 22-Aug-18
+        15:10:02 GMT; path=/; Domain=api.hackerone.com; HttpOnly
+      X-Request-Id:
+      - 6114bb66-4dad-4bb0-8913-530c38758156
+      Etag:
+      - W/"554f310fcd9c49f5d069ea686e38e8e2"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        www.youtube-nocookie.com; connect-src ''self'' www.google-analytics.com errors.hackerone.net;
+        font-src ''self''; form-action ''self''; frame-ancestors ''none''; img-src
+        ''self'' data: cover-photos.hackerone-user-content.com hackathon-photos.hackerone-user-content.com
+        profile-photos.hackerone-user-content.com hackerone-attachments.s3.amazonaws.com;
+        media-src ''self'' hackerone-attachments.s3.amazonaws.com; script-src ''self''
+        www.google-analytics.com; style-src ''self'' ''unsafe-inline''; report-uri
+        https://errors.hackerone.net/api/30/csp-report/?sentry_key=61c1e2f50d21487c97a071737701f598'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - DENY
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18="; pin-sha256="r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=";
+        pin-sha256="K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q="; pin-sha256="iie1VXtL7HzAMF+/PVPR9xzT80kQxdZeJ+zduCB3uj0=";
+        pin-sha256="cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A="; pin-sha256="bIlWcjiKq1mftH/xd7Hw1JO77Cr+Gv+XYcGUQWwO+A4=";
+        pin-sha256="tXD+dGAP8rGY4PW1be90cOYEwg7pZ4G+yPZmIZWPTSg="; max-age=600; includeSubDomains;
+        report-uri="https://hackerone.report-uri.io/r/default/hpkp/reportOnly"
+      Server:
+      - cloudflare-nginx
+      Cf-Ray:
+      - 3926c1aecfdb2c72-AMS
+    body:
+      encoding: UTF-8
+      string: '{"data":{"type":"activity-bounty-suggested","id":"1946481","attributes":{"message":"This
+        report is great, I think we should award a high bounty.","created_at":"2017-08-22T15:10:02.699Z","updated_at":"2017-08-22T15:10:02.699Z","internal":true,"bounty_amount":"5,000","bonus_amount":"2,500"},"relationships":{"actor":{"data":{"type":"user","id":"193855","attributes":{"username":"sjors","name":null,"disabled":false,"created_at":"2017-08-22T13:18:29.084Z","profile_picture":{"62x62":"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png","82x82":"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png","110x110":"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png","260x260":"/assets/avatars/default-71a302d706457f3d3a31eb30fa3e73e6cf0b1d677b8fa218eaeaffd67ae97918.png"}}}}}}}'
+    http_version: 
+  recorded_at: Tue, 22 Aug 2017 15:10:02 GMT
+recorded_with: VCR 3.0.3

--- a/lib/hackerone/client.rb
+++ b/lib/hackerone/client.rb
@@ -10,6 +10,8 @@ require_relative "client/member"
 require_relative "client/user"
 require_relative "client/group"
 require_relative "client/structured_scope"
+require_relative "client/swag"
+require_relative "client/bounty"
 
 module HackerOne
   module Client

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -57,13 +57,18 @@ module HackerOne
         delegate :message, :internal, to: :attributes
       end
 
+      class BountySuggested < Activity
+        delegate :message, :bounty_amount, :bonus_amount, to: :attributes
+      end
+
       ACTIVITY_TYPE_CLASS_MAPPING = {
         'activity-bounty-awarded' => BountyAwarded,
         'activity-swag-awarded' => SwagAwarded,
         'activity-user-assigned-to-bug' => UserAssignedToBug,
         'activity-bug-triaged' => BugTriaged,
         'activity-reference-id-added' => ReferenceIdAdded,
-        'activity-comment' => CommentAdded
+        'activity-comment' => CommentAdded,
+        'activity-bounty-suggested' => BountySuggested
       }.freeze
 
       def self.build(activity_data)

--- a/lib/hackerone/client/bounty.rb
+++ b/lib/hackerone/client/bounty.rb
@@ -7,6 +7,7 @@ module HackerOne
         :awarded_amount,
         :awarded_bonus_amount,
         :awarded_currency,
+        :created_at,
         to: :attributes
       )
 

--- a/lib/hackerone/client/bounty.rb
+++ b/lib/hackerone/client/bounty.rb
@@ -1,0 +1,28 @@
+module HackerOne
+  module Client
+    class Bounty
+      delegate(
+        :amount,
+        :bonus_amount,
+        :awarded_amount,
+        :awarded_bonus_amount,
+        :awarded_currency,
+        to: :attributes
+      )
+
+      def initialize(bounty)
+        @bounty = bounty
+      end
+
+      def id
+        @bounty[:id]
+      end
+
+      private
+
+      def attributes
+        OpenStruct.new(@bounty[:attributes])
+      end
+    end
+  end
+end

--- a/lib/hackerone/client/report.rb
+++ b/lib/hackerone/client/report.rb
@@ -1,9 +1,12 @@
+require_relative './resource_helper'
 require_relative './weakness'
 require_relative './activity'
 
 module HackerOne
   module Client
     class Report
+      include ResourceHelper
+
       def initialize(report)
         @report = report
       end
@@ -81,6 +84,46 @@ module HackerOne
 
       def program
         @program || Program.find(relationships[:program][:data][:attributes][:handle])
+      end
+
+      def award_bounty(message:, amount:, bonus_amount: nil)
+        request_body = {
+          message: message,
+          amount: amount,
+          bonus_amount: bonus_amount
+        }
+
+        response_body = make_post_request(
+          "reports/#{id}/bounties",
+          request_body: request_body
+        )
+        Bounty.new(response_body)
+      end
+
+      def award_swag(message:)
+        request_body = {
+          message: message
+        }
+
+        response_body = make_post_request(
+          "reports/#{id}/swags",
+          request_body: request_body
+        )
+        Swag.new(response_body)
+      end
+
+      def suggest_bounty(message:, amount:, bonus_amount: nil)
+        request_body = {
+          message: message,
+          amount: amount,
+          bonus_amount: bonus_amount
+        }
+
+        response_body = make_post_request(
+          "reports/#{id}/bounty_suggestions",
+          request_body: request_body
+        )
+        Activities.build(response_body)
       end
 
       def assign_to_user(name)

--- a/lib/hackerone/client/resource_helper.rb
+++ b/lib/hackerone/client/resource_helper.rb
@@ -1,0 +1,25 @@
+module HackerOne
+  module Client
+    module ResourceHelper
+      def parse_response(response)
+        HackerOne::Client::Api.parse_response(response)
+      end
+
+      def make_post_request(url, request_body:)
+        response = HackerOne::Client::Api.hackerone_api_connection.post do |req|
+          req.headers['Content-Type'] = 'application/json'
+          req.url url
+          req.body = { data: request_body }.to_json
+        end
+
+        parse_response(response)
+      end
+
+      private
+
+      def api_connection
+        HackerOne::Client::Api.hackerone_api_connection
+      end
+    end
+  end
+end

--- a/lib/hackerone/client/swag.rb
+++ b/lib/hackerone/client/swag.rb
@@ -1,0 +1,21 @@
+module HackerOne
+  module Client
+    class Swag
+      delegate :sent, to: :attributes
+
+      def initialize(swag)
+        @swag = swag
+      end
+
+      def id
+        @swag[:id]
+      end
+
+      private
+
+      def attributes
+        OpenStruct.new(@swag[:attributes])
+      end
+    end
+  end
+end

--- a/lib/hackerone/client/swag.rb
+++ b/lib/hackerone/client/swag.rb
@@ -1,7 +1,7 @@
 module HackerOne
   module Client
     class Swag
-      delegate :sent, to: :attributes
+      delegate :sent, :created_at, to: :attributes
 
       def initialize(swag)
         @swag = swag

--- a/spec/hackerone/client/report_spec.rb
+++ b/spec/hackerone/client/report_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe HackerOne::Client::Report do
 
       expect(result).to be_a HackerOne::Client::Swag
       expect(result.sent).to eq false
+      expect(result.created_at).to be_present
     end
   end
 

--- a/spec/hackerone/client/report_spec.rb
+++ b/spec/hackerone/client/report_spec.rb
@@ -98,6 +98,55 @@ RSpec.describe HackerOne::Client::Report do
     end
   end
 
+  describe '#award_bounty' do
+    it 'creates a bounty' do
+      result = VCR.use_cassette(:award_a_bounty) do
+        report.award_bounty(
+          message: 'Thanks for the great report!',
+          amount: 1330,
+          bonus_amount: 7
+        )
+      end
+
+      expect(result).to be_a HackerOne::Client::Bounty
+      expect(result.amount).to eq '1330.00'
+      expect(result.bonus_amount).to eq '7.00'
+      expect(result.awarded_amount).to eq '1330.00'
+      expect(result.awarded_bonus_amount).to eq '7.00'
+      expect(result.awarded_currency).to eq 'USD'
+    end
+  end
+
+  describe '#suggest_award' do
+    it 'creates a bounty' do
+      result = VCR.use_cassette(:suggest_a_bounty) do
+        report.suggest_bounty(
+          message: 'This report is great, I think we should award a high bounty.',
+          amount: 5000,
+          bonus_amount: 2500
+        )
+      end
+
+      expect(result).to be_a HackerOne::Client::Activities::BountySuggested
+      expect(result.message).to eq 'This report is great, I think we should award a high bounty.'
+      expect(result.bounty_amount).to eq '5,000'
+      expect(result.bonus_amount).to eq '2,500'
+    end
+  end
+
+  describe '#award_swag' do
+    it 'creates a bounty' do
+      result = VCR.use_cassette(:award_swag) do
+        report.award_swag(
+          message: 'Enjoy this cool swag!',
+        )
+      end
+
+      expect(result).to be_a HackerOne::Client::Swag
+      expect(result.sent).to eq false
+    end
+  end
+
   describe "#activities" do
     it "returns a list of activities" do
       expect(report.activities).to all(be_an(HackerOne::Client::Activities::Activity))

--- a/spec/hackerone/client/report_spec.rb
+++ b/spec/hackerone/client/report_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe HackerOne::Client::Report do
       expect(result.message).to eq 'This report is great, I think we should award a high bounty.'
       expect(result.bounty_amount).to eq '5,000'
       expect(result.bonus_amount).to eq '2,500'
+      expect(result.created_at).to be_present
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/oreoshake/hackerone-client/issues/21

Usage:

```
> report = HackerOne::Client::Api.new('$HANDLE').report($REPORT_ID)
> report.award_bounty(message: "Here's your bounty!", amount: 500, bonus_amount: 50)
> report.suggest_bounty(message: "I suggest $500 with a small bonus. Report is well-written.", amount: 500, bonus_amount: 50)
> report.award_swag(message: "Here's your T-Shirt")
```

(For bounty and suggest bounty, either `amount` or `bonus_amount` is required, not both.)