### PR TITLE
Allow authentication to be passed during initialization of the Client::Api

### DIFF
--- a/hackerone-client.gemspec
+++ b/hackerone-client.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.3"
   spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency 'activesupport', '~> 3.0', '> 3.0'
+  spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
I agree that keeping credentials in repos is not good practice, but it works for my purpose. I have changed the logic a bit to allow for using env as well as params during instantiation. So my code now looks like

```
client = HackerOne::Client::Api.new("showmax", {token_name: "<redacted>", token: "<redacted>"})
```

Let me know what you think about it.