### PR TITLE
Allow newer active_support

### DIFF
--- a/hackerone-client.gemspec
+++ b/hackerone-client.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "vcr", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 2.3"
   spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency 'activesupport', '~> 3.0', '> 3.0'
+  spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
As agreed in #28 , please allow usage of newer `ActiveSupport` as locking it breaks some deployments.