### PR TITLE
Added pagination on reporters. Get program memberships/groups types and  users  that manage program

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ program = HackerOne::Client::Program.find("insert-program-name-here")
 
 # returns all common responses
 program.common_responses
+
+# pagination on program reporters
+default: program.reporters(page_number: 1, page_size: 25)
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Hackerone::Client
 
 A limited client library for interacting with HackerOne. Currently only supports a few operations:
-
+### Client
 ```ruby
+Initialize Client
 client = HackerOne::Client::Api.new("github")
 
 # GET '/reports' returns all reports in the "new" state for a given program
@@ -39,8 +40,27 @@ report.award_swag(message: "Here's your T-Shirt")
 
 # GET `/{program}/reporters` returns a list of unique reporters that have reported to your program
 client.reporters
-
+```
+### Program
+```
+Initialize program
 program = HackerOne::Client::Program.find("insert-program-name-here")
+
+# returns all groups, memership types and users that manage the program. **It does not include reporters**
+program.users
+
+# get all groups in a program
+program.users[:relationships][:groups]
+
+ # > program.users[:relationships][:groups]
+ => {:data=>[{:id=>"xxx", :type=>"group", :attributes=>{:name=>"Admin", :created_at=>"20xx-06-16T15:44:16.721Z",
+ :permissions=>["user_management", "program_management"]}}, {:id=>"xxxx", :type=>"group", :attributes=>{:name=>"Standard",
+ :created_at=>"20xx-06-16T15:44:16.751Z", :permissions=>["report_management", "reward_management"]}}, {:id=>"xxxx", 
+ :type=>"group", :attributes=>{:name=>"View/Comment/Triage", :created_at=>"20xx-11-11T19:39:55.393Z", :permissions=>["report_management"]}}]}
+ 
+ # get all members in a program
+ program.users[:relationships][:members]
+
 
 # returns all common responses
 program.common_responses

--- a/lib/hackerone/client/program.rb
+++ b/lib/hackerone/client/program.rb
@@ -40,6 +40,14 @@ module HackerOne
       def find_group(groupname)
         groups.find { |group| group.name == groupname }
       end
+      
+      # Get reporters via pages.
+       def reporters(page_number: 1, page_size: 25)
+        make_get_request(
+          "programs/#{id}/reporters",
+          params: { page: { number: page_number, size: page_size } }
+        )
+      end
 
       def common_responses(page_number: 1, page_size: 100)
         make_get_request(

--- a/lib/hackerone/client/program.rb
+++ b/lib/hackerone/client/program.rb
@@ -24,6 +24,12 @@ module HackerOne
       def attributes
         OpenStruct.new(@program[:attributes])
       end
+       # List all groups, membership types and users for a program
+      def users()
+        make_get_request(
+          "programs/#{id}"
+          )
+      end
 
       def member?(username)
         find_member(username).present?


### PR DESCRIPTION
Added pagination on reporters. Added attributes on reporters to choose page_size or get a page_number. 

example uage:
program.reporters(page_number: 1, page_size: 25)