### PR TITLE
Changed bounty amount parser to allow floats

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ HackerOne::Client.high_range = 2500...5000
 HackerOne::Client.critical_range = 5000...100_000_000
 ```
 
+### Configuration
+
+In order to configure whether error handling is strict or lenient, set the `HACKERONE_CLIENT_LENIENT_MODE` variable.
+
+Setting this variable will make the client try to absorb errors, like a malformed bounty or bonus amount. Not setting this variable will cause the client to raise errors. 
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/oreoshake/hackerone-client. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/hackerone/client.rb
+++ b/lib/hackerone/client.rb
@@ -24,6 +24,8 @@ module HackerOne
     DEFAULT_HIGH_RANGE = 2500...4999
     DEFAULT_CRITICAL_RANGE = 5000...100_000_000
 
+    LENIENT_MODE_ENV_VARIABLE = 'HACKERONE_CLIENT_LENIENT_MODE'
+
     class << self
       ATTRS = [:low_range, :medium_range, :high_range, :critical_range].freeze
       attr_accessor :program

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -29,12 +29,28 @@ module HackerOne
       class BountyAwarded < Activity
         def bounty_amount
           formatted_bounty_amount = attributes.bounty_amount || "0"
-          Float(formatted_bounty_amount) rescue 0
+          if ENV['HACKERONE_CLIENT_LENIENT_MODE']
+            Float(formatted_bounty_amount) rescue 0
+          else
+            begin
+              Float(formatted_bounty_amount)
+            rescue ArgumentError
+              raise ArgumentError.new("Improperly formatted bounty amount")
+            end
+          end
         end
 
         def bonus_amount
           formatted_bonus_amount = attributes.bonus_amount || "0"
-          Float(formatted_bonus_amount) rescue 0
+          if ENV['HACKERONE_CLIENT_LENIENT_MODE']
+            Float(formatted_bonus_amount) rescue 0
+          else
+            begin
+              Float(formatted_bonus_amount)
+            rescue ArgumentError
+              raise ArgumentError.new("Improperly formatted bonus amount")
+            end
+          end
         end
       end
 

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -29,7 +29,7 @@ module HackerOne
       class BountyAwarded < Activity
         def bounty_amount
           formatted_bounty_amount = attributes.bounty_amount || "0"
-          if ENV['HACKERONE_CLIENT_LENIENT_MODE']
+          if ENV[HackerOne::Client::LENIENT_MODE_ENV_VARIABLE]
             Float(formatted_bounty_amount) rescue 0
           else
             begin
@@ -42,7 +42,7 @@ module HackerOne
 
         def bonus_amount
           formatted_bonus_amount = attributes.bonus_amount || "0"
-          if ENV['HACKERONE_CLIENT_LENIENT_MODE']
+          if ENV[HackerOne::Client::LENIENT_MODE_ENV_VARIABLE]
             Float(formatted_bonus_amount) rescue 0
           else
             begin

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -29,12 +29,12 @@ module HackerOne
       class BountyAwarded < Activity
         def bounty_amount
           formatted_bounty_amount = attributes.bounty_amount || "0"
-          formatted_bounty_amount.gsub(/[^\d\.]/, "").to_f
+          Float(formatted_bounty_amount) rescue 0
         end
 
         def bonus_amount
           formatted_bonus_amount = attributes.bonus_amount || "0"
-          formatted_bonus_amount.gsub(/[^\d\.]/, "").to_f
+          Float(formatted_bonus_amount) rescue 0
         end
       end
 

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -29,12 +29,12 @@ module HackerOne
       class BountyAwarded < Activity
         def bounty_amount
           formatted_bounty_amount = attributes.bounty_amount || "0"
-          formatted_bounty_amount.gsub(/[^\d]/, "").to_i
+          formatted_bounty_amount.gsub(/[^\d\.]/, "").to_f
         end
 
         def bonus_amount
           formatted_bonus_amount = attributes.bonus_amount || "0"
-          formatted_bonus_amount.gsub(/[^\d]/, "").to_i
+          formatted_bonus_amount.gsub(/[^\d\.]/, "").to_f
         end
       end
 

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -51,7 +51,23 @@ RSpec.describe HackerOne::Client::Activities do
       expect(activity.bonus_amount).to eq 0
     end
 
-    it 'returns 0 when bounty amount or bonus amount are malformed' do
+    it 'throws an error when bounty amount or bonus amount is malformed' do
+      example = {
+        'type' => 'activity-bounty-awarded',
+        'attributes' => {
+          'bounty_amount' => 'steve',
+          'bonus_amount' => 'harvey'
+        }
+      }.with_indifferent_access
+
+      activity = HackerOne::Client::Activities.build example
+
+      expect{ activity.bounty_amount }.to raise_error "Improperly formatted bounty amount"
+      expect{ activity.bonus_amount }.to raise_error "Improperly formatted bonus amount"
+    end
+
+    it 'returns 0 when bounty amount or bonus amount are malformed with lenient mode' do
+      ENV['HACKERONE_CLIENT_LENIENT_MODE'] = 'true'
       example = {
         'type' => 'activity-bounty-awarded',
         'attributes' => {

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe HackerOne::Client::Activities do
       }.with_indifferent_access
     end
 
+    before(:each) do
+      ENV.delete("HACKERONE_CLIENT_LENIENT_MODE")
+    end
+
     it 'creates the activity type with attributes' do
       activity = HackerOne::Client::Activities.build example
 

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe HackerOne::Client::Activities do
     end
 
     it 'returns 0 when bounty amount or bonus amount are malformed with lenient mode' do
-      ENV['HACKERONE_CLIENT_LENIENT_MODE'] = 'true'
+      ENV[HackerOne::Client::LENIENT_MODE_ENV_VARIABLE] = 'true'
       example = {
         'type' => 'activity-bounty-awarded',
         'attributes' => {

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -50,6 +50,21 @@ RSpec.describe HackerOne::Client::Activities do
       expect(activity.bounty_amount).to eq 0
       expect(activity.bonus_amount).to eq 0
     end
+
+    it 'returns 0 when bounty amount or bonus amount are malformed' do
+      example = {
+        'type' => 'activity-bounty-awarded',
+        'attributes' => {
+          'bounty_amount' => 'steve',
+          'bonus_amount' => 'harvey'
+        }
+      }.with_indifferent_access
+
+      activity = HackerOne::Client::Activities.build example
+
+      expect(activity.bounty_amount).to eq 0
+      expect(activity.bonus_amount).to eq 0
+    end
   end
 
   describe HackerOne::Client::Activities::SwagAwarded do

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe HackerOne::Client::Activities do
     end
 
     before(:each) do
-      ENV.delete("HACKERONE_CLIENT_LENIENT_MODE")
+      ENV.delete(HackerOne::Client::LENIENT_MODE_ENV_VARIABLE)
     end
 
     it 'creates the activity type with attributes' do

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe HackerOne::Client::Activities do
           'created_at' => '2016-02-02T04:05:06.000Z',
           'updated_at' => '2016-02-02T04:05:06.000Z',
           'internal' => false,
-          'bounty_amount' => '500',
-          'bonus_amount' => '50'
+          'bounty_amount' => '500.00',
+          'bonus_amount' => '50.00'
         },
         'relationships' => {
           'actor' => {
@@ -35,8 +35,8 @@ RSpec.describe HackerOne::Client::Activities do
       activity = HackerOne::Client::Activities.build example
 
       expect(activity.class).to eq described_class
-      expect(activity.bounty_amount).to eq 500
-      expect(activity.bonus_amount).to eq 50
+      expect(activity.bounty_amount).to eq 500.00
+      expect(activity.bonus_amount).to eq 50.00
     end
 
     it 'does not fail when bounty or bonus amount is not given' do


### PR DESCRIPTION
Currently, [the bounty_amount object on H1](https://api.hackerone.com/reference/#bounty) is returned as a float, while previously it was a int. As such, the previous way we used to parse these numbers was insufficient, and led to a bug of the amount being off by a factor of 100:

```
bounty_amount: 500.00
Expected: 500
  Actual: 50000
```

This PR makes the gsub filters less stringent to allow a decimal point to pass through, and casts to float instead of to int. 