### PR TITLE
don't lock version numbers in development dependencies

### DIFF
--- a/hackerone-client.gemspec
+++ b/hackerone-client.gemspec
@@ -20,11 +20,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "vcr", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 2.3"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "vcr"
+  spec.add_development_dependency "webmock"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "activesupport"
 end


### PR DESCRIPTION
I'm not sure why this was done in the first place, but it sure would make using this as a library harder