### PR TITLE
Changed update severity to prefer symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ report.add_report_reference(reference)
 # Triage an issue (add a reference and set state to :triaged)
 report.triage(reference)
 
-# Set the severity on a report (rating can be none, low, medium, high or critical)
-report.update_severity(rating: "high")
+# Set the severity on a report (rating can be :none, :low, :medium, :high or :critical)
+report.update_severity(rating: :high)
 
 # POST /reports/{id}/bounty_suggestions
 report.suggest_bounty(message: "I suggest $500 with a small bonus. Report is well-written.", amount: 500, bonus_amount: 50)

--- a/lib/hackerone/client/report.rb
+++ b/lib/hackerone/client/report.rb
@@ -32,7 +32,7 @@ module HackerOne
         medium
         high
         critical
-      ).freeze
+      ).map(&:to_sym).freeze
 
       class << self
         def add_on_state_change_hook(proc)

--- a/lib/hackerone/client/report.rb
+++ b/lib/hackerone/client/report.rb
@@ -32,7 +32,7 @@ module HackerOne
         medium
         high
         critical
-      ).map(&:to_sym).freeze
+      ).freeze
 
       class << self
         def add_on_state_change_hook(proc)
@@ -174,7 +174,7 @@ module HackerOne
       end
 
       def update_severity(rating:)
-        raise ArgumentError, "Invalid severity rating" unless SEVERITY_RATINGS.include?(rating)
+        raise ArgumentError, "Invalid severity rating" unless SEVERITY_RATINGS.include?(rating.to_s)
 
         request_body = {
           type: "severity",

--- a/spec/hackerone/client/report_spec.rb
+++ b/spec/hackerone/client/report_spec.rb
@@ -250,13 +250,13 @@ RSpec.describe HackerOne::Client::Report do
   describe "#severity" do
     it "updates severity" do
       VCR.use_cassette(:update_severity) do
-        report.update_severity(rating: "high")
-        expect(report.severity[:rating]).to eq("high")
+        report.update_severity(rating: :high)
+        expect(report.severity[:rating]).to eq(:high)
       end
     end
 
     it "errors on invalid severity" do
-      expect { report.update_severity(rating: "invalid") }.to raise_error "Invalid severity rating"
+      expect { report.update_severity(rating: :invalid) }.to raise_error "Invalid severity rating"
     end
   end
 end


### PR DESCRIPTION
As discussed here: https://github.com/oreoshake/hackerone-client/pull/54#pullrequestreview-380599505, this PR makes it so that we only accept symbols for the `update_severity` method