### PR TITLE
Get Attachment Objects from report

### DIFF
--- a/fixtures/vcr_cassettes/report.yml
+++ b/fixtures/vcr_cassettes/report.yml
@@ -191,7 +191,28 @@ http_interactions:
             },
             "attachments": {
               "data": [
-
+                {
+                  "id": "936424",
+                  "type": "attachment",
+                  "attributes": {
+                    "expiring_url": "https://redacted.aws.s3.link",
+                    "created_at": "2020-08-04T18:34:09.446Z",
+                    "file_name": "2182_FtX8VdFq.jpg",
+                    "content_type": "image/jpeg",
+                    "file_size": 653695
+                  }
+                },
+                {
+                  "id": "936425",
+                  "type": "attachment",
+                  "attributes": {
+                    "expiring_url": "https://redacted.aws.s3.link",
+                    "created_at": "2020-08-04T18:34:28.970Z",
+                    "file_name": "swagger_parse.py",
+                    "content_type": "text/x-python-script",
+                    "file_size": 482
+                  }
+                }
               ]
             },
             "vulnerability_types": {

--- a/lib/hackerone/client.rb
+++ b/lib/hackerone/client.rb
@@ -14,6 +14,7 @@ require_relative "client/group"
 require_relative "client/structured_scope"
 require_relative "client/swag"
 require_relative "client/address"
+require_relative "client/attachment"
 require_relative "client/bounty"
 require_relative "client/incremental/activities"
 
@@ -112,7 +113,7 @@ module HackerOne
       # severity_rating: severity of report, must be one of https://api.hackerone.com/reference/#severity-ratings
       # source: where the report came from, i.e. API, Bugcrowd, etc.
       #
-      # returns an Hackerone::Client::Report object or raises an error if
+      # returns an HackerOne::Client::Report object or raises an error if
       # error during creation
       def create_report(title:, summary:, impact:, severity_rating:, source:)
         raise ArgumentError, "Program cannot be nil" unless program

--- a/lib/hackerone/client/activity.rb
+++ b/lib/hackerone/client/activity.rb
@@ -15,6 +15,12 @@ module HackerOne
           attributes.internal
         end
 
+        def attachments
+          @attachments ||= activity.relationships.fetch(:attachments, {})
+              .fetch(:data, [])
+              .map { |attachment| HackerOne::Client::Attachment.new(attachment) }
+        end
+
         private
 
         def relationships

--- a/lib/hackerone/client/attachment.rb
+++ b/lib/hackerone/client/attachment.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module HackerOne
+  module Client
+    class Attachment
+      delegate :expiring_url, :file_name, :content_type, :created_at, \
+        :file_size, to: :attributes
+
+      def initialize(attachment)
+        @attachment = attachment
+      end
+
+      def id
+        @attachment[:id]
+      end
+
+      private
+
+      def attributes
+        OpenStruct.new(@attachment[:attributes])
+      end
+    end
+  end
+end

--- a/lib/hackerone/client/report.rb
+++ b/lib/hackerone/client/report.rb
@@ -135,6 +135,12 @@ module HackerOne
         classification_label.split("-").first
       end
 
+      def attachments
+        @attachments ||= relationships.fetch(:attachments, {})
+            .fetch(:data, [])
+            .map { |attachment| HackerOne::Client::Attachment.new(attachment) }
+      end
+
       def activities
         if ships = relationships.fetch(:activities, {}).fetch(:data, [])
           ships.map do |activity_data|

--- a/spec/hackerone/client/activity_spec.rb
+++ b/spec/hackerone/client/activity_spec.rb
@@ -28,6 +28,21 @@ RSpec.describe HackerOne::Client::Activities do
                 "updated_at" => "2016-02-02T04:05:06.000Z"
               }
             }
+          },
+          "attachments" => {
+            "data": [
+              {
+                "id": "1337",
+                "type": "attachment",
+                "attributes": {
+                  "expiring_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                  "created_at": "2020-02-02T00:00:00.000Z",
+                  "file_name": "root.rb",
+                  "content_type": "text/x-ruby",
+                  "file_size": 2871
+                }
+              }
+            ]
           }
         }
       }.with_indifferent_access
@@ -43,6 +58,7 @@ RSpec.describe HackerOne::Client::Activities do
       expect(activity.class).to eq described_class
       expect(activity.bounty_amount).to eq 500.00
       expect(activity.bonus_amount).to eq 50.00
+      expect(activity.attachments).to all(be_an(HackerOne::Client::Attachment))
     end
 
     it "does not fail when bounty or bonus amount is not given" do
@@ -147,6 +163,21 @@ RSpec.describe HackerOne::Client::Activities do
                 }
               }
             }
+          },
+          "attachments" => {
+            "data": [
+              {
+                "id": "1337",
+                "type": "attachment",
+                "attributes": {
+                  "expiring_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                  "created_at": "2020-02-02T00:00:00.000Z",
+                  "file_name": "root.rb",
+                  "content_type": "text/x-ruby",
+                  "file_size": 2871
+                }
+              }
+            ]
           }
         }
       }.with_indifferent_access
@@ -157,6 +188,7 @@ RSpec.describe HackerOne::Client::Activities do
 
       expect(activity.class).to eq described_class
       expect(activity.swag).to_not be_nil
+      expect(activity.attachments).to all(be_an(HackerOne::Client::Attachment))
     end
   end
 
@@ -189,6 +221,21 @@ RSpec.describe HackerOne::Client::Activities do
                 }
               }
             }
+          },
+          "attachments" => {
+            "data": [
+              {
+                "id": "1337",
+                "type": "attachment",
+                "attributes": {
+                  "expiring_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                  "created_at": "2020-02-02T00:00:00.000Z",
+                  "file_name": "root.rb",
+                  "content_type": "text/x-ruby",
+                  "file_size": 2871
+                }
+              }
+            ]
           }
         }
       }.with_indifferent_access
@@ -200,6 +247,7 @@ RSpec.describe HackerOne::Client::Activities do
       expect(activity.class).to eq described_class
       expect(activity.message).to_not be_nil
       expect(activity.internal).to_not be_nil
+      expect(activity.attachments).to all(be_an(HackerOne::Client::Attachment))
     end
   end
 
@@ -250,6 +298,21 @@ RSpec.describe HackerOne::Client::Activities do
                 }
               }
             }
+          },
+          "attachments" => {
+            "data": [
+              {
+                "id": "1337",
+                "type": "attachment",
+                "attributes": {
+                  "expiring_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                  "created_at": "2020-02-02T00:00:00.000Z",
+                  "file_name": "root.rb",
+                  "content_type": "text/x-ruby",
+                  "file_size": 2871
+                }
+              }
+            ]
           }
         }
       }.with_indifferent_access
@@ -260,6 +323,7 @@ RSpec.describe HackerOne::Client::Activities do
 
       expect(activity.class).to eq described_class
       expect(activity.assigned_user).to_not be_nil
+      expect(activity.attachments).to all(be_an(HackerOne::Client::Attachment))
     end
   end
 
@@ -292,6 +356,21 @@ RSpec.describe HackerOne::Client::Activities do
                 }
               }
             }
+          },
+          "attachments" => {
+            "data": [
+              {
+                "id": "1337",
+                "type": "attachment",
+                "attributes": {
+                  "expiring_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                  "created_at": "2020-02-02T00:00:00.000Z",
+                  "file_name": "root.rb",
+                  "content_type": "text/x-ruby",
+                  "file_size": 2871
+                }
+              }
+            ]
           }
         }
       }.with_indifferent_access
@@ -301,6 +380,7 @@ RSpec.describe HackerOne::Client::Activities do
       activity = HackerOne::Client::Activities.build example
 
       expect(activity.class).to eq described_class
+      expect(activity.attachments).to all(be_an(HackerOne::Client::Attachment))
     end
   end
 
@@ -335,6 +415,21 @@ RSpec.describe HackerOne::Client::Activities do
                 }
               }
             }
+          },
+          "attachments" => {
+            "data": [
+              {
+                "id": "1337",
+                "type": "attachment",
+                "attributes": {
+                  "expiring_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                  "created_at": "2020-02-02T00:00:00.000Z",
+                  "file_name": "root.rb",
+                  "content_type": "text/x-ruby",
+                  "file_size": 2871
+                }
+              }
+            ]
           }
         }
       }.with_indifferent_access
@@ -346,6 +441,7 @@ RSpec.describe HackerOne::Client::Activities do
       expect(activity.class).to eq described_class
       expect(activity.reference).to eq "reference"
       expect(activity.reference_url).to eq "https://example.com/reference"
+      expect(activity.attachments).to all(be_an(HackerOne::Client::Attachment))
     end
   end
 end

--- a/spec/hackerone/client/attachment_spec.rb
+++ b/spec/hackerone/client/attachment_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "active_support/core_ext/hash"
+
+RSpec.describe HackerOne::Client::Attachment do
+  let (:attachment_data) do
+    {
+      expiring_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      created_at: "2016-02-02T04:05:06.000Z",
+      file_name: "root.rb",
+      content_type: "image/jpeg",
+      file_size: 2871
+    }
+  end
+
+  let(:example) do
+    {
+      id: "1337",
+      type: "attachment",
+      attributes: attachment_data,
+    }.with_indifferent_access
+  end
+
+  it "creates the address type with attributes" do
+    attachment = HackerOne::Client::Attachment.new example
+    expect(attachment.class).to eq described_class
+    expect(attachment.id).to eq "1337"
+
+    attachment_data.keys.each do |key|
+      expect(attachment.send key.to_s).to eq attachment_data[key]
+    end
+  end
+end

--- a/spec/hackerone/client/attachment_spec.rb
+++ b/spec/hackerone/client/attachment_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe HackerOne::Client::Attachment do
     }.with_indifferent_access
   end
 
-  it "creates the address type with attributes" do
+  it "creates the attachment object with attributes" do
     attachment = HackerOne::Client::Attachment.new example
     expect(attachment.class).to eq described_class
     expect(attachment.id).to eq "1337"

--- a/spec/hackerone/client/report_spec.rb
+++ b/spec/hackerone/client/report_spec.rb
@@ -207,6 +207,12 @@ RSpec.describe HackerOne::Client::Report do
     end
   end
 
+  describe "#attachments" do
+    it "returns a list of attachments" do
+      expect(report.attachments).to all(be_an(HackerOne::Client::Attachment))
+    end
+  end
+
 
   describe "#activities" do
     it "returns a list of activities" do


### PR DESCRIPTION
Added a helper method to the `report` object to get Attachment objects. Complete with signed commits 😄 

~TODO: Also be able to pull attachments from comments~ Done 🎉 